### PR TITLE
Introduce WSDD_ARGS to directly pass wsdd arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ Docker image for wsdd.py.
 wsdd implements a Web Service Discovery host daemon. This enables (Samba) hosts, like your local NAS device or Linux server, to be found by Web Service Discovery Clients like Windows.
 
 ## Supported environment variables
-HOSTNAME: Samba Netbios name to report.
+`HOSTNAME`: Samba Netbios name to report.
 
-WORKGROUP: Workgroup name
+`WORKGROUP`: Workgroup name
 
-DOMAIN: Report being a member of an AD DOMAIN. Disables WORKGROUP if set. 
+`DOMAIN`: Report being a member of an AD DOMAIN. Disables `WORKGROUP` if set.
+
+Alternatively, you can pass all desired wsdd arguments in the environment variable `WSDD_ARGS`. In this case, the arguments are passed as-is and all other environment variables are ignored.
 
 ## Running container
 ### From command line

--- a/docker-cmd.sh
+++ b/docker-cmd.sh
@@ -2,22 +2,23 @@
 
 args=( )
 
-if [ ! -z "${HOSTNAME}" ]; then
-	args+=( "-n $HOSTNAME ")
-else 
-	echo "HOSTNAME environment variable must be set."
-	exit 1
+if [ ! -z "${WSDD_ARGS}" ]; then
+  args=${WSDD_ARGS}
+else
+	if [ ! -z "${HOSTNAME}" ]; then
+		args+=( "-n $HOSTNAME ")
+	else
+		echo "HOSTNAME environment variable must be set."
+		exit 1
+	fi
+
+	if  [ ! -z "${WORKGROUP}" ]; then
+		args+=( "-w $WORKGROUP " )
+	fi
+
+	if  [ ! -z "${DOMAIN}" ]; then
+		args+=( "-d $DOMAIN " )
+	fi
 fi
-
-if  [ ! -z "${WORKGROUP}" ]; then
-	args+=( "-w $WORKGROUP " )
-fi
-
-if  [ ! -z "${DOMAIN}" ]; then
-	args+=( "-d $DOMAIN " )
-fi
-
-
 
 exec python wsdd.py ${args}
-


### PR DESCRIPTION
Thank you for this project.
I came across the use case where I had to set other wsdd arguments such as `--interface` and `--uuid`.
This PR introduces an environment variable `WSDD_ARGS` to pass the entire argument string straight to wsdd, bypassing any other configuration.
Does this make sense to you?